### PR TITLE
玛娜火炮及玛娜盾造价和补给消耗平衡（第一版）

### DIFF
--- a/common/units/IRIS_MANA.txt
+++ b/common/units/IRIS_MANA.txt
@@ -86,14 +86,14 @@ sub_units = {
 		}
 		combat_width = 2
 		max_strength = 2
-		max_organisation = 10
-		default_morale = 0.1
+		max_organisation = 20 #10
+		default_morale = 0.3 #0.1
 		manpower = 600
 		training_time = 180
 		suppression = 2
 		breakthrough = 0.1
-		weight = 1.5
-		supply_consumption = 0.28
+		weight = 1 #1.5
+		supply_consumption = 0.22 #0.28
 		#can_be_parachuted = yes
 		need = {
 			refined_mana = 12
@@ -123,7 +123,7 @@ sub_units = {
 		}
 		combat_width = 3
 		need = {
-			Magic_ap_equipment = 36
+			Magic_ap_equipment = 30 #36
 			refined_mana = 16
 		}
 		#can_be_parachuted = yes
@@ -134,7 +134,7 @@ sub_units = {
 		default_morale = 0.1
 		training_time = 180
 		weight = 0.6
-		supply_consumption = 0.4
+		supply_consumption = 0.25 #0.4
 		forest = {
 			attack = 0.05
 		}

--- a/common/units/equipment/mana.txt
+++ b/common/units/equipment/mana.txt
@@ -301,24 +301,25 @@ equipments = {
 		interface_category = interface_category_land
 		active = yes
 		#Misc Abilities
-		maximum_speed = 4
+		maximum_speed = 5 #4
 		reliability = 0.8
 		#Defensive Abilities
-		defense = 6
-		breakthrough = 2
-		hardness = 0.65
+		defense = 8 #6
+		breakthrough = 16 #2
+		hardness = 0.7 #0.65
 		armor_value = 20
 		#Offensive Abilities
-		soft_attack = 1
-		hard_attack = 1
+		soft_attack = 0 #1
+		hard_attack = 0 #1
 		ap_attack = 0
 		air_attack = 0
 		#Space taken in convoy
 		lend_lease_cost = 2
-		build_cost_ic = 7
+		build_cost_ic = 5 #7
 		resources = {
 			raw_mana = 2
-			chromium = 1
+			#chromium = 1
+			steel = 1
 		}
 		upgrades = {
 			special_historical_equipment_upgrade_build_cost
@@ -350,14 +351,15 @@ equipments = {
 		visual_level = 1
 
 		#Misc Abilities
-		defense = 11
-		breakthrough = 3.5
-		hardness = 0.7
-		armor_value = 27
-		build_cost_ic = 8.2
+		defense = 12 #11
+		breakthrough = 24 #3.5
+		hardness = 0.8
+		armor_value = 30 #27
+		build_cost_ic = 7 #8.2
 		resources = {
 			raw_mana = 2
-			chromium = 2
+			#chromium = 2
+			steel = 1
 		}
 	}
 	Magic_Shield_equipment_3 = {
@@ -368,14 +370,14 @@ equipments = {
 		visual_level = 2
 
 		defense = 18
-		breakthrough = 5
-		hardness = 0.75
-		armor_value = 38
-		build_cost_ic = 10.5
+		breakthrough = 35 #5
+		hardness = 0.85 #0.75
+		armor_value = 50 #38
+		build_cost_ic = 10 #10.5
 
 		resources = {
 			raw_mana = 3
-			chromium = 2
+			steel = 2
 		}
 	}
 	#机动型魔导器
@@ -436,7 +438,7 @@ equipments = {
 		upgrades = {
 		}
 		#Misc Abilities
-		reliability = 0.75
+		reliability = 0.8 #0.75
 		maximum_speed = 5
 		#Defensive Abilities
 		defense = 5
@@ -450,7 +452,7 @@ equipments = {
 		air_attack = 3
 		#Space taken in convoy
 		lend_lease_cost = 4
-		build_cost_ic = 4.5
+		build_cost_ic = 4 #4.5
 		resources = {
 			tungsten = 1
 			steel = 1
@@ -496,8 +498,8 @@ equipments = {
 		build_cost_ic = 6
 		resources = {
 			tungsten = 1
-			steel = 1
-			raw_mana = 1
+			steel = 2 #1
+			raw_mana = 2 #1
 		}
 	}
 	Magic_ap_equipment_2 = {
@@ -521,7 +523,7 @@ equipments = {
 		resources = {
 			tungsten = 1
 			steel = 2
-			raw_mana = 2
+			raw_mana = 3 #2
 		}
 	}
 	#高能魔导激光=防空炮+反坦克炮


### PR DESCRIPTION
1.使玛娜火炮及玛娜盾的补给消耗降低至正常水平（玛娜炮与自行火箭炮一致，玛娜盾与轻坦一致）
2.初级玛娜炮造价与二级火炮一致（为4ic），每提升一级增加2ic
3.玛娜炮与玛娜盾需要的资源提高