### PR TITLE
调整游戏性

### DIFF
--- a/common/defines/IRIS_defines.lua
+++ b/common/defines/IRIS_defines.lua
@@ -450,7 +450,7 @@ NDefines.NNavy.NAVAL_RANGE_TO_INGAME_DISTANCE = 0.18 -- Scale the ship stats "na
 
 NDefines.NCountry.MAJOR_MIN_FACTORIES = 50
 NDefines.NDiplomacy.BASE_SURRENDER_LEVEL = 0.85
--- NDefines.NDiplomacy.VOLUNTEERS_PER_TARGET_PROVINCE = 0.0
+NDefines.NDiplomacy.VOLUNTEERS_PER_TARGET_PROVINCE = 0.0
 -- NDefines.NDiplomacy.VOLUNTEERS_PER_COUNTRY_ARMY = 0.01
 NDefines.NDiplomacy.VOLUNTEERS_RETURN_EQUIPMENT = 0.95
 NDefines.NDiplomacy.VOLUNTEERS_TRANSFER_SPEED = 7
@@ -459,6 +459,21 @@ NDefines.NDiplomacy.VOLUNTEERS_TRANSFER_SPEED = 7
 -- Military
 --------------------------------------------------------------------------------------------------------------
 
-NDefines.NMilitary.UNIT_EXPERIENCE_PER_COMBAT_HOUR = 0.0002 -- 0.0001
-NDefines.NMilitary.EXPERIENCE_LOSS_FACTOR = 0.85 -- 1.00                 -- percentage of experienced solders who die when manpower is removed
-NDefines.NMilitary.EQUIPMENT_COMBAT_LOSS_FACTOR = 0.60 -- 0.70	 	   -- % of equipment lost to strength ratio in combat, so some % is returned if below 1
+NDefines.NMilitary.UNIT_EXPERIENCE_PER_COMBAT_HOUR = 0.0003 -- 0.0001
+--NDefines.NMilitary.EXPERIENCE_LOSS_FACTOR = 0.85 -- 1.00                 -- percentage of experienced solders who die when manpower is removed
+NDefines.NMilitary.EQUIPMENT_COMBAT_LOSS_FACTOR = 0.50 -- 0.70	 	   -- % of equipment lost to strength ratio in combat, so some % is returned if below 1
+EXPERIENCE_COMBAT_FACTOR = 0.35 -- 0.25
+
+-- 穿甲机制
+NDefines.NMilitary.PIERCING_THRESHOLDS = {					-- Our piercing / their armor must be this value to deal damage fraction equal to the index in the array below [higher number = higher penetration]. If armor is 0, 1.00 will be returned.
+1.00,
+0.75,
+0.50,
+0.00, --there isn't much point setting this higher than 0
+}
+NDefines.NMilitary.PIERCING_THRESHOLD_DAMAGE_VALUES = {	-- 0 armor will always receive maximum damage (so add overmatching at your own peril). the system expects at least 2 values, with no upper limit.
+1.00,
+0.75, -- 0.80
+0.50, -- 0.65
+0.25, -- 0.50
+}

--- a/common/units/equipment/modules/00_tank_modules.txt
+++ b/common/units/equipment/modules/00_tank_modules.txt
@@ -321,19 +321,19 @@ equipment_modules = {
 		xp_cost = 2
 		dismantle_cost_ic = 0.5
 		add_stats = {
-			build_cost_ic = 0.75
+			#build_cost_ic = 0.50 # 0.75 ## 进行了调整，同步原版数值时请注意
 			reliability = 0.2
 			defense = 3
 			
 		}
 
-		multiply_stats = {
-			breakthrough = -0.25
-		}
+		#multiply_stats = { ## 进行了调整，同步原版数值时请注意
+		#	breakthrough = -0.25
+		#}
 
 		can_convert_from = {
 			module_category = tank_light_turret_type
-			convert_cost_ic = 0.75
+			#convert_cost_ic = 0.50 # 0.75 ## 进行了调整，同步原版数值时请注意
 		}
 	}
 
@@ -426,18 +426,18 @@ equipment_modules = {
 		xp_cost = 2
 		dismantle_cost_ic = 1
 		add_stats = {
-			build_cost_ic = 1.5
+			#build_cost_ic = 1 # 1.5 ## 进行了调整，同步原版数值时请注意
 			reliability = 0.2
 			defense = 3
 		}
 
-		multiply_stats = {
-			breakthrough = -0.25
-		}
+		#multiply_stats = { ## 进行了调整，同步原版数值时请注意
+		#	breakthrough = -0.25
+		#}
 
 		can_convert_from = {
 			module_category = tank_medium_turret_type
-			convert_cost_ic = 1.5
+			#convert_cost_ic = 1 # 1.5 ## 进行了调整，同步原版数值时请注意
 		}
 
 	}
@@ -517,18 +517,18 @@ equipment_modules = {
 		dismantle_cost_ic = 1
 		xp_cost = 2
 		add_stats = {
-			build_cost_ic = 5
+			#build_cost_ic = 4.5 # 5 ## 进行了调整，同步原版数值时请注意
 			reliability = 0.2
 			defense = 3
 		}
 
-		multiply_stats = {
-			breakthrough = -0.25
-		}
+		#multiply_stats = { ## 进行了调整，同步原版数值时请注意
+		#	breakthrough = -0.25
+		#}
 
 		can_convert_from = {
 			module_category = tank_heavy_turret_type
-			convert_cost_ic = 5
+			#convert_cost_ic = 4.5 # 5 ## 进行了调整，同步原版数值时请注意
 		}
 
 	}

--- a/common/units/equipment/motorized.txt
+++ b/common/units/equipment/motorized.txt
@@ -1,0 +1,95 @@
+equipments = {
+
+	motorized_equipment = {
+		year = 1936
+
+		is_archetype = yes
+		picture = archetype_motorized_equipment		
+		is_buildable = no
+		type = {
+			#infantry #Removing inf type 
+			motorized
+		}
+		group_by = archetype
+		
+		interface_category = interface_category_land
+		
+		maximum_speed = 12
+		reliability = 0.8
+		hardness = 0.1
+
+		breakthrough = 10 #5 ###还原至摩托化装备添加突破值版本的属性，同步原版数值时请注意			
+
+		#Space taken in convoy
+		lend_lease_cost = 5
+
+		build_cost_ic = 2.5
+		resources = {
+			#oil = 1
+			rubber = 1
+			steel = 1
+		}
+		
+		fuel_consumption = 1.2
+		supply_truck = yes
+	}
+
+	motorized_equipment_0 = { # Introducing WW1 style trucks
+		year = 1936
+
+		archetype = motorized_equipment
+		priority = 30
+		maximum_speed = 10
+		reliability = 0.65
+		breakthrough = 8 #2 ###还原至摩托化装备添加突破值版本的属性，同步原版数值时请注意			
+	}
+
+	motorized_equipment_1 = {
+		year = 1936
+
+		archetype = motorized_equipment
+		parent = motorized_equipment_0
+		priority = 30			
+	}
+
+
+	motorbike_equipment = {
+		year = 1938
+
+		is_archetype = yes
+		picture = archetype_motorized_equipment
+		is_buildable = no
+		type = {
+			motorized
+			support
+		}
+		group_by = archetype
+		
+		interface_category = interface_category_land
+		
+		maximum_speed = 12
+		reliability = 0.9
+		#hardness = 0
+
+		breakthrough = 1
+
+		#Space taken in convoy
+		lend_lease_cost = 2
+
+		build_cost_ic = 1.5
+		resources = {
+			#oil = 1
+			rubber = 1
+			steel = 1
+		}
+		
+		fuel_consumption = 0.5
+	}
+
+	motorbike_equipment_1 = {
+
+		archetype = motorbike_equipment
+		priority = 1 #Very low
+	}
+
+}

--- a/common/units/tank_destroyer_brigade.txt
+++ b/common/units/tank_destroyer_brigade.txt
@@ -22,7 +22,7 @@ sub_units = {
 			category_tank_destroyers
 		}
 
-		combat_width = 2
+		combat_width = 1 # 2 ## 进行了调整，同步原版数值时请注意
 
 		need = {
 			light_tank_destroyer_chassis = 50
@@ -35,7 +35,7 @@ sub_units = {
 		weight = 1
 		supply_consumption = 0.2
 
-		breakthrough = -0.42
+		#breakthrough = -0.42 ## 进行了调整，同步原版数值时请注意
 
 		suppression = 1.0
 
@@ -90,7 +90,7 @@ sub_units = {
 		}
 
 
-		combat_width = 2
+		combat_width = 1 # 2 ## 进行了调整，同步原版数值时请注意
 
 		need = {
 			medium_tank_destroyer_chassis = 50
@@ -103,7 +103,7 @@ sub_units = {
 		weight = 1.25
 		supply_consumption = 0.22
 
-		breakthrough = -0.25
+		#breakthrough = -0.25 ## 进行了调整，同步原版数值时请注意
 		
 		suppression = 1.25
 
@@ -162,7 +162,7 @@ sub_units = {
 		}
 
 
-		combat_width = 2
+		combat_width = 1 # 2 ## 进行了调整，同步原版数值时请注意
 
 		need = {
 			heavy_tank_destroyer_chassis = 40
@@ -174,7 +174,7 @@ sub_units = {
 		weight = 1.5
 		supply_consumption = 0.3
 
-		breakthrough = -0.25
+		#breakthrough = -0.25 ## 进行了调整，同步原版数值时请注意
 
 		suppression = 1.25
 		
@@ -248,7 +248,7 @@ sub_units = {
 		weight = 1.75
 		supply_consumption = 0.4
 
-		breakthrough = -0.25
+		#breakthrough = -0.25 ## 进行了调整，同步原版数值时请注意
 
 		suppression = 1.25
 
@@ -309,7 +309,7 @@ sub_units = {
 		}
 
 
-		combat_width = 2
+		combat_width = 1 # 2 ## 进行了调整，同步原版数值时请注意
 
 		need = {
 			modern_tank_destroyer_chassis = 50
@@ -322,7 +322,7 @@ sub_units = {
 		weight = 1.5
 		supply_consumption = 0.25
 		
-		breakthrough = -0.25
+		#breakthrough = -0.25 ## 进行了调整，同步原版数值时请注意
 
 		suppression = 1.25
 		


### PR DESCRIPTION
-平衡：
--加强摩托化、突击炮突破数值
--突击炮造价更低廉
--装甲歼击车营宽度降低，使其与反坦克炮营、摩托化反坦克炮营一致
--减少装备战损
--减少未被击穿受到的伤害
--陆军师从战斗中获得经验更快
--陆军师从经验等级获得的战斗加成提高

-回退：
--志愿军数量不受省份数量影响
--初始部队经验损失率回退