### PR TITLE
陆军将领攻防技能、强于适应特质回调至削弱前的版本

### DIFF
--- a/common/ai_templates/template_ELN.txt
+++ b/common/ai_templates/template_ELN.txt
@@ -55,23 +55,23 @@ infantry_ELN = {
 		}
 	}
 	
-	infantry_default_mana_ELN = {
-	
-		upgrade_prio = {
-			base = 1
-
-			modifier = {
-				factor = 0
-			}
-		}
-		
-		target_template = {
-			
-			regiments = {
-				Arcane_Battle_Camp = 4
-			}
-		}
-	}
+	#infantry_default_mana_ELN = {
+	#
+	#	upgrade_prio = {
+	#		base = 1
+	#
+	#		modifier = {
+	#			factor = 0
+	#		}
+	#	}
+	#	
+	#	target_template = {
+	#		
+	#		regiments = {
+	#			Arcane_Battle_Camp = 4
+	#		}
+	#	}
+	#}
 	
 	infantry_Upgrade_ELN = {
 
@@ -93,13 +93,13 @@ infantry_ELN = {
 		target_template = {
 			
 			support = {
-				engineer = 1
-				artillery = 1
+				Arcane_Golem_Camp = 1
+				Magic_Breakthrough_support = 1
 				anti_tank = 1
 			}
 			
 			regiments = {
-				infantry = 8
+				Arcane_Battle_Camp = 8
 				Heavy_Magic_Guide_Battle_Battalion = 1
 				Magic_Breakthrough_Camp = 2
 			}

--- a/common/unit_leader/00_attack_skills.txt
+++ b/common/unit_leader/00_attack_skills.txt
@@ -1,0 +1,249 @@
+leader_attack_skills = {
+
+	### NAVY ###
+	1 = {
+		cost = 100
+		type = navy
+		modifier = {
+			naval_damage_factor = 0.05
+		}
+	}
+
+	2 = {
+		cost = 200
+		type = navy
+		modifier = {
+			naval_damage_factor = 0.10
+		}
+	}
+
+	3 = {
+		cost = 400
+		type = navy
+		modifier = {
+			naval_damage_factor = 0.15
+		}
+	}
+
+	4 = {
+		cost = 800
+		type = navy
+		modifier = {
+			naval_damage_factor = 0.20
+		}
+	}
+
+	5 = {
+		cost = 1600
+		type = navy
+		modifier = {
+			naval_damage_factor = 0.25
+		}
+	}
+
+	6 = {
+		cost = 3200
+		type = navy
+		modifier = {
+			naval_damage_factor = 0.30
+		}
+	}
+
+	7 = {
+		cost = 6400
+		type = navy
+		modifier = {
+			naval_damage_factor = 0.35
+		}
+	}
+
+	8 = {
+		cost = 12800
+		type = navy
+		modifier = {
+			naval_damage_factor = 0.40
+		}
+	}
+
+	9 = {
+		cost = 25600
+		type = navy
+		modifier = {
+			naval_damage_factor = 0.45
+		}
+	}
+
+	10 = {
+		cost = 51200
+		type = navy
+		modifier = {
+			naval_damage_factor = 0.50
+		}
+	}
+
+	### Corps Commander ###
+	1 = {
+		cost = 100
+		type = corps_commander
+		modifier = {
+			offence = 0.05
+		}
+	}
+		
+	2 = {
+		cost = 200
+		type = corps_commander
+		modifier = {
+			offence = 0.10
+		}
+	}
+	
+	
+	3 = {
+		cost = 400
+		type = corps_commander
+		modifier = {
+			offence = 0.15
+		}
+	}
+	
+	4 = {
+		cost = 800
+		type = corps_commander
+		modifier = {
+			offence = 0.20
+		}
+	}
+	
+	5 = {
+		cost = 1600
+		type = corps_commander
+		modifier = {
+			offence = 0.25
+		}
+	}
+
+	6 = {
+		cost = 3200
+		type = corps_commander
+		modifier = {
+			offence = 0.30
+		}
+	}
+
+	7 = {
+		cost = 6400
+		type = corps_commander
+		modifier = {
+			offence = 0.35
+		}
+	}
+
+	8 = {
+		cost = 12800
+		type = corps_commander
+		modifier = {
+			offence = 0.40
+		}
+	}
+
+	9 = {
+		cost = 25600
+		type = corps_commander
+		modifier = {
+			offence = 0.45
+		}
+	}
+	
+	10 = {
+		cost = 51200
+		type = corps_commander
+		modifier = {
+			offence = 0.50
+		}
+	}
+	
+	
+	### Field Marshal ###
+	1 = {
+		cost = 100
+		type = field_marshal
+		modifier = {
+			offence = 0.05
+		}
+	}
+	
+	
+	2 = {
+		cost = 200
+		type = field_marshal
+		modifier = {
+			offence = 0.10
+		}
+	}
+	
+	
+	3 = {
+		cost = 400
+		type = field_marshal
+		modifier = {
+			offence = 0.15
+		}
+	}
+	
+	4 = {
+		cost = 800
+		type = field_marshal
+		modifier = {
+			offence = 0.20
+		}
+	}
+	
+	5 = {
+		cost = 1600
+		type = field_marshal
+		modifier = {
+			offence = 0.25
+		}
+	}
+
+	6 = {
+		cost = 3200
+		type = field_marshal
+		modifier = {
+			offence = 0.30
+		}
+	}	
+
+	7 = {
+		cost = 6400
+		type = field_marshal
+		modifier = {
+			offence = 0.35
+		}
+	}	
+
+	8 = {
+		cost = 12800
+		type = field_marshal
+		modifier = {
+			offence = 0.40
+		}
+	}	
+
+	9 = {
+		cost = 25600
+		type = field_marshal
+		modifier = {
+			offence = 0.45
+		}
+	}	
+	
+	10 = {
+		cost = 51200
+		type = field_marshal
+		modifier = {
+			offence = 0.50
+		}
+	}
+}

--- a/common/unit_leader/00_defense_skills.txt
+++ b/common/unit_leader/00_defense_skills.txt
@@ -1,0 +1,248 @@
+leader_defense_skills = {
+
+	### NAVY ###
+	1 = {
+		cost = 100
+		type = navy
+		modifier = {
+			naval_defense_factor = 0.05
+		}
+	}
+
+	2 = {
+		cost = 200
+		type = navy
+		modifier = {
+			naval_defense_factor = 0.10
+		}
+	}
+
+	3 = {
+		cost = 400
+		type = navy
+		modifier = {
+			naval_defense_factor = 0.15
+		}
+	}
+
+	4 = {
+		cost = 800
+		type = navy
+		modifier = {
+			naval_defense_factor = 0.20
+		}
+	}
+
+	5 = {
+		cost = 1600
+		type = navy
+		modifier = {
+			naval_defense_factor = 0.25
+		}
+	}
+
+	6 = {
+		cost = 3200
+		type = navy
+		modifier = {
+			naval_defense_factor = 0.30
+		}
+	}
+
+	7 = {
+		cost = 6400
+		type = navy
+		modifier = {
+			naval_defense_factor = 0.35
+		}
+	}
+
+	8 = {
+		cost = 12800
+		type = navy
+		modifier = {
+			naval_defense_factor = 0.40
+		}
+	}
+
+	9 = {
+		cost = 25600
+		type = navy
+		modifier = {
+			naval_defense_factor = 0.45
+		}
+	}
+	
+	10 = {
+		cost = 51200
+		type = navy
+		modifier = {
+			naval_defense_factor = 0.50
+		}
+	}
+
+	### Corps Commander ###
+	1 = {
+		cost = 100
+		type = corps_commander
+		modifier = {
+			defence = 0.05
+		}
+	}
+		
+	2 = {
+		cost = 200
+		type = corps_commander
+		modifier = {
+			defence = 0.10
+		}
+	}
+	
+	
+	3 = {
+		cost = 400
+		type = corps_commander
+		modifier = {
+			defence = 0.15
+		}
+	}
+	
+	4 = {
+		cost = 800
+		type = corps_commander
+		modifier = {
+			defence = 0.20
+		}
+	}
+	
+	5 = {
+		cost = 1600
+		type = corps_commander
+		modifier = {
+			defence = 0.25
+		}
+	}
+
+	6 = {
+		cost = 3200
+		type = corps_commander
+		modifier = {
+			defence = 0.30
+		}
+	}
+
+	7 = {
+		cost = 6400
+		type = corps_commander
+		modifier = {
+			defence = 0.35
+		}
+	}
+
+	8 = {
+		cost = 12800
+		type = corps_commander
+		modifier = {
+			defence = 0.40
+		}
+	}
+
+	9 = {
+		cost = 25600
+		type = corps_commander
+		modifier = {
+			defence = 0.45
+		}
+	}
+	
+	10 = {
+		cost = 51200
+		type = corps_commander
+		modifier = {
+			defence = 0.50
+		}
+	}
+	
+	### Field Marshal ###
+	1 = {
+		cost = 100
+		type = field_marshal
+		modifier = {
+			defence = 0.05
+		}
+	}
+	
+	
+	2 = {
+		cost = 200
+		type = field_marshal
+		modifier = {
+			defence = 0.10
+		}
+	}
+	
+	
+	3 = {
+		cost = 400
+		type = field_marshal
+		modifier = {
+			defence = 0.15
+		}
+	}
+	
+	4 = {
+		cost = 800
+		type = field_marshal
+		modifier = {
+			defence = 0.20
+		}
+	}
+	
+	5 = {
+		cost = 1600
+		type = field_marshal
+		modifier = {
+			defence = 0.25
+		}
+	}
+
+	6 = {
+		cost = 3200
+		type = field_marshal
+		modifier = {
+			defence = 0.30
+		}
+	}	
+
+	7 = {
+		cost = 6400
+		type = field_marshal
+		modifier = {
+			defence = 0.35
+		}
+	}	
+
+	8 = {
+		cost = 12800
+		type = field_marshal
+		modifier = {
+			defence = 0.40
+		}
+	}	
+
+	9 = {
+		cost = 25600
+		type = field_marshal
+		modifier = {
+			defence = 0.45
+		}
+	}	
+	
+	10 = {
+		cost = 51200
+		type = field_marshal
+		modifier = {
+			defence = 0.50
+		}
+	}
+}

--- a/common/unit_leader/00_traits.txt
+++ b/common/unit_leader/00_traits.txt
@@ -1248,7 +1248,7 @@ leader_traits = {
 		}
 		cost = 1000
 		modifier = {
-			terrain_penalty_reduction = 0.30
+			terrain_penalty_reduction = 0.50
 			acclimatization_cold_climate_gain_factor = 0.1
 			acclimatization_hot_climate_gain_factor = 0.1
 		}

--- a/common/units/infantry.txt
+++ b/common/units/infantry.txt
@@ -163,17 +163,17 @@ sub_units = {
 		suppression = 1
 		weight = 0.5
 		supply_consumption = 0.05
-		breakthrough = 0.3
+		breakthrough = 1.0 # 0.3 ## 进行了调整，同步原版数值时请注意
 	
 		need = {
 			infantry_equipment = 150
 		}
 
 		marsh = {
-			attack = 0.3
+			attack = 0.4 # 0.3 ## 进行了调整，同步原版数值时请注意
 		}
 		river = {
-			attack = 0.3
+			attack = 0.45 # 0.3 ## 进行了调整，同步原版数值时请注意
 		}
 		amphibious = {
 			attack = 0.5
@@ -221,17 +221,17 @@ sub_units = {
 		suppression = 1
 		weight = 0.5
 		supply_consumption = 0.05
-		breakthrough = 0.3
+		breakthrough = 1.0 # 0.3 ## 进行了调整，同步原版数值时请注意
 	
 		need = {
 			infantry_equipment = 150
 		}
 
 		marsh = {
-			attack = 0.3
+			attack = 0.4 # 0.3 ## 进行了调整，同步原版数值时请注意
 		}
 		river = {
-			attack = 0.3
+			attack = 0.45 # 0.3 ## 进行了调整，同步原版数值时请注意
 		}
 		amphibious = {
 			attack = 0.5
@@ -279,19 +279,19 @@ sub_units = {
 		weight = 0.5
 		
 		supply_consumption = 0.05
-		breakthrough = 0.3
+		breakthrough = 1.0 # 0.3 ## 进行了调整，同步原版数值时请注意
 	
 		need = {
 			infantry_equipment = 140
 		}
 
 		hills = {
-			attack = 0.2
+			attack = 0.25 # 0.2 ## 进行了调整，同步原版数值时请注意
 			defence = 0.05
 			movement = 0.1
 		}
 		mountain = {
-			attack = 0.35
+			attack = 0.50 # 0.35 ## 进行了调整，同步原版数值时请注意
 			defence = 0.1
 			movement = 0.2
 		}
@@ -336,6 +336,8 @@ sub_units = {
 		suppression = 1
 		weight = 0.5
 		supply_consumption = 0.05
+		breakthrough = 1 ## 进行了调整，同步原版数值时请注意
+		defense = 0.5 ## 进行了调整，同步原版数值时请注意
 
 		can_be_parachuted = yes
 	

--- a/history/units/ELN.txt
+++ b/history/units/ELN.txt
@@ -107,7 +107,17 @@ division_template = {
 	regiments = {
 		Arcane_Battle_Camp = { x = 0 y = 0 }
 		Arcane_Battle_Camp = { x = 0 y = 1 }
-		Heavy_Magic_Guide_Battle_Battalion = { x = 1 y = 0 }
+		Arcane_Battle_Camp = { x = 0 y = 2 }
+		Arcane_Battle_Camp = { x = 1 y = 0 }
+		Arcane_Battle_Camp = { x = 1 y = 1 }
+		Arcane_Battle_Camp = { x = 1 y = 2 }
+		Heavy_Magic_Guide_Battle_Battalion = { x = 2 y = 0 }
+		Heavy_Magic_Guide_Battle_Battalion = { x = 2 y = 1 }
+		Heavy_Magic_Guide_Battle_Battalion = { x = 2 y = 2 }
+	}
+	support = {
+		Arcane_Golem_Camp = { x = 0 y = 0 }
+		artillery = { x = 0 y = 1 }
 	}
 }
 
@@ -116,13 +126,17 @@ division_template = {
 	regiments = {
 		Arcane_Battle_Camp = { x = 0 y = 0 }
 		Arcane_Battle_Camp = { x = 0 y = 1 }
+		Arcane_Battle_Camp = { x = 0 y = 2 }
 		Arcane_Battle_Camp = { x = 1 y = 0 }
 		Arcane_Battle_Camp = { x = 1 y = 1 }
-		Heavy_Magic_Guide_Battle_Battalion = { x = 2 y = 0 }
-		Heavy_Magic_Guide_Battle_Battalion = { x = 2 y = 1 }
+		Arcane_Battle_Camp = { x = 1 y = 2 }
+		Arcane_Battle_Camp = { x = 2 y = 0 }
+		Arcane_Battle_Camp = { x = 2 y = 1 }
+		Arcane_Battle_Camp = { x = 2 y = 2 }
 	}
 	support = {
-		recon = { x = 0 y = 0 }
+		Arcane_Golem_Camp = { x = 0 y = 0 }
+		artillery = { x = 0 y = 1 }
 	}
 }
 
@@ -131,8 +145,21 @@ division_template = {
 	regiments = {
 		Arcane_Battle_Camp = { x = 0 y = 0 }
 		Arcane_Battle_Camp = { x = 0 y = 1 }
+		Arcane_Battle_Camp = { x = 0 y = 2 }
 		Arcane_Battle_Camp = { x = 1 y = 0 }
 		Arcane_Battle_Camp = { x = 1 y = 1 }
+		Arcane_Battle_Camp = { x = 1 y = 2 }
+		Arcane_Battle_Camp = { x = 2 y = 0 }
+		Arcane_Battle_Camp = { x = 2 y = 1 }
+		Arcane_Battle_Camp = { x = 2 y = 2 }
+		Heavy_Magic_Guide_Battle_Battalion = { x = 3 y = 0 }
+		Heavy_Magic_Guide_Battle_Battalion = { x = 3 y = 1 }
+		artillery_brigade = { x = 4 y = 0 }
+	}
+	support = {
+		Arcane_Golem_Camp = { x = 0 y = 0 }
+		artillery = { x = 0 y = 1 }
+		recon = { x = 0 y = 2 }
 	}
 }
 
@@ -309,19 +336,19 @@ units = {
 			is_name_ordered = yes
 			name_order = 5
 		}
-		location = 133
+		location = 7869
 		division_template = "爱丽诺前线魔导军团"		# All motorized are frontline, best equipment
 		start_experience_factor = 0.3
 	}
 	division = {
 		name = "爱丽诺魔导近卫军第一师"
-		location = 7869
+		location = 6660
 		division_template = "爱丽诺魔导近卫军"		# All motorized are frontline, best equipment
 		start_experience_factor = 1
 	}
 	division = {
 		name = "爱丽诺魔导近卫军第二师"
-		location = 8221
+		location = 6660
 		division_template = "爱丽诺魔导近卫军"		# All motorized are frontline, best equipment
 		start_experience_factor = 1
 	}


### PR DESCRIPTION
-陆军将领攻防技能每级+0.05
-强于适应地形惩罚抵消50%
-略微提升山地步兵、海军步兵地形适性
-略微提升特种部队的突破属性
-中等提升伞兵的防御属性